### PR TITLE
Update binary for Ubuntu 22.04 (jammy) amd64

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,10 @@
         {
             "name": "Alexander Rice",
             "email": "alexanderrice@rtonational.com"
+        },
+        {
+            "name": "Corie Slate",
+            "email": "corie@houseoftech.com"
         }
     ],
     "minimum-stability": "stable",


### PR DESCRIPTION
I used the corvus docker container to download the debian package, then extracted the binary.

```sh
curl -sLO https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
ar x wkhtmltox_0.12.6.1-2.jammy_amd64.deb
tar xvf data.tar.xz
```